### PR TITLE
Fix code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def nosan_server(tmp_path_factory):
     ca.cert_pem.write_to_path(ca_bundle)
 
     context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     server_cert.configure_cert(context)
     server = HTTPServer(("localhost", 0), SimpleHTTPRequestHandler)
     server.socket = context.wrap_socket(server.socket, server_side=True)


### PR DESCRIPTION
Fixes [https://github.com/akaday/fantastic-enigma/security/code-scanning/1](https://github.com/akaday/fantastic-enigma/security/code-scanning/1)

To fix the problem, we need to ensure that the SSL context created by `ssl.create_default_context` uses a secure protocol version. The best way to do this is to set the `minimum_version` attribute of the SSL context to `ssl.TLSVersion.TLSv1_2`. This change will ensure that only TLSv1.2 and higher versions are used, which are considered secure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
