### PR TITLE
Fix code scanning alert no. 6: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -163,12 +163,14 @@ class HTTPDigestAuth(AuthBase):
             hash_utf8 = argon2_utf8
         elif _algorithm == "SHA-256":
 
-            def sha256_utf8(x):
+            ph = PasswordHasher()
+
+            def argon2_utf8(x):
                 if isinstance(x, str):
                     x = x.encode("utf-8")
-                return hashlib.sha256(x).hexdigest()
+                return ph.hash(x)
 
-            hash_utf8 = sha256_utf8
+            hash_utf8 = argon2_utf8
         elif _algorithm == "SHA-512":
 
             ph = PasswordHasher()


### PR DESCRIPTION
Fixes [https://github.com/akaday/fantastic-enigma/security/code-scanning/6](https://github.com/akaday/fantastic-enigma/security/code-scanning/6)

To fix the problem, we need to replace the use of SHA-256 with a more secure hashing algorithm suitable for password hashing. Argon2 is a good choice as it is designed to be computationally expensive and includes a per-password salt by default.

- Replace the SHA-256 hashing function with Argon2.
- Ensure that the Argon2 hashing function is used consistently across all relevant parts of the code.
- Update the import statements to include the necessary Argon2 library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
